### PR TITLE
Fix Issue #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ wstool update
 catkin build
 echo "source ~/catkin_ws/devel/setup.bash" >> ~/.bashrc
 source ~/.bashrc
-sudo apt-get install ros-melodic-husky-simulator
+sudo apt-get install ros-melodic-husky-simulator ros-melodic-eigen-conversions
 export HUSKY_GAZEBO_DESCRIPTION=$(rospack find husky_gazebo)/urdf/description.gazebo.xacro
 ```
 


### PR DESCRIPTION
Turns out there was another dependency which is not automatically installed with ROS: Eigen conversions. Added that to the instructions in the README for using our repo.